### PR TITLE
yield cpu time to other processes (fixes #3 high cpu usage)

### DIFF
--- a/TheFilenalCountdown/Form1.cs
+++ b/TheFilenalCountdown/Form1.cs
@@ -129,6 +129,9 @@ namespace TheFilenalCountdown
 
                 while (exitFlag == false)
                 {
+                    // Yield CPU time to other processes
+                    Thread.Sleep(10);
+
                     // Processes all the events in the queue.
                     Application.DoEvents();
                 }


### PR DESCRIPTION
simply adding `Thread.Sleep(10)` onto the loop reduced my CPU usage to 0.1% at most.